### PR TITLE
configure: fix build _gettext.c

### DIFF
--- a/configure
+++ b/configure
@@ -264,6 +264,7 @@ fi
 # Add CPPFLAGS and CFLAGS to CC for testing features
 XCC="$CC `$SED -n -e 's/CPPLAGS+=*\(.*\)/\1/p' $CONFIG_MK`"
 XCC="$XCC `$SED -n -e 's/CFLAGS+=*\(.*\)/\1/p' $CONFIG_MK`"
+XCC="$XCC `$SED -n -e 's/LDFLAGS+=*\(.*\)/\1/p' $CONFIG_MK`"
 
 if [ -z "$GETTEXT" ]; then
 	printf "Testing for gettext ... "


### PR DESCRIPTION
On OpenBSD the _gettext.c compile failed with ld error,  undefined symbol: libintl_gettext. I set LDFLAGS, but configure script don't use only the CPPFLAGS and CFLAGS. This change fix this issue.